### PR TITLE
added function for checking size of trampoline in trampoline/Makefile

### DIFF
--- a/trampoline/Makefile
+++ b/trampoline/Makefile
@@ -14,5 +14,13 @@ bin.o: boot_trampoline.bin
 boot_trampoline.bin: $(BOOTOBJS)
 	ld $(LDFLAGS) -Tboot_trampoline.ld $^ -o $@
 
+check_bin_size: $(BOOTOBJS)
+	-$(eval tmpf := $(shell mktemp))
+	-$(eval tmpbin := $(shell mktemp))
+	@cat boot_trampoline.ld | sed -e "/^OUTPUT_FORMAT/d" > $(tmpf)
+	@ld $(LDFLAGS) -T$(tmpf) $^ -o $(tmpbin)
+	size -A -x $(tmpbin) 
+	@rm $(tmpf) $(tmpbin)
+
 clean:
 	-rm *.o boot_trampoline.bin


### PR DESCRIPTION
現在のカーネルのサイズを簡単に調べられる機能を追加した

例 $make check_bin_size

size -A -x /tmp/tmp.GOXu5S9Kdx
/tmp/tmp.GOXu5S9Kdx  :
section     size    addr
.text      0xa87     0x8
.rodata     0x22   0xa90
.data      0x238   0xab2
.bss       0x250   0xd00
.comment    0x34     0x0
Total      0xf65
